### PR TITLE
Ensure Strapi CLI runs with Node specifier resolution

### DIFF
--- a/cms/scripts/run-strapi.mjs
+++ b/cms/scripts/run-strapi.mjs
@@ -7,11 +7,24 @@ const packagePath = require.resolve('@strapi/strapi/package.json');
 const strapiBin = path.join(path.dirname(packagePath), 'bin', 'strapi.js');
 
 const args = process.argv.slice(2);
+const specifierFlag = '--experimental-specifier-resolution=node';
+const env = { ...process.env };
+
+if (typeof env.NODE_OPTIONS === 'string' && env.NODE_OPTIONS.trim().length > 0) {
+  const options = env.NODE_OPTIONS.split(/\s+/u);
+  if (!options.includes(specifierFlag)) {
+    options.push(specifierFlag);
+    env.NODE_OPTIONS = options.join(' ');
+  }
+} else {
+  env.NODE_OPTIONS = specifierFlag;
+}
+
 const nodeArgs = [strapiBin, ...args];
 
 const child = spawn(process.execPath, nodeArgs, {
   stdio: 'inherit',
-  env: process.env,
+  env,
 });
 
 child.on('exit', (code, signal) => {

--- a/cms/scripts/run-strapi.mjs
+++ b/cms/scripts/run-strapi.mjs
@@ -2,6 +2,10 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+const ensureEnvModulePath = new URL('./ensure-env.mjs', import.meta.url);
+
+await import(ensureEnvModulePath);
+
 const require = createRequire(import.meta.url);
 const packagePath = require.resolve('@strapi/strapi/package.json');
 const strapiBin = path.join(path.dirname(packagePath), 'bin', 'strapi.js');


### PR DESCRIPTION
## Summary
- update the Strapi launcher script to append the `--experimental-specifier-resolution=node` flag to NODE_OPTIONS when spawning the CLI so extensionless ESM imports resolve correctly

## Testing
- not run (environment setup not completed)

------
https://chatgpt.com/codex/tasks/task_e_68e7b0488c888329b1173e8749c20650